### PR TITLE
Fix PyMOL startup when running tests

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -96,7 +96,8 @@ jobs:
           --cov-branch \
           --cov-report html:test_coverage/html \
           --cov-report annotate:test_coverage/annotation \
-          --cov-report term
+          --cov-report term \
+          -v
     - name: Upload code coverage results
       uses: actions/upload-artifact@v1
       with:

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -4,6 +4,7 @@ import PDB_plugin as plugin
 import pymol
 
 import pytest
+import sys
 
 
 def test_initialize_plugin():
@@ -20,15 +21,21 @@ def test_initialize_plugin():
 @pytest.mark.parametrize(
     'argv',
     [
-        [''],
-        ['invalid_pdb_id'],
-        ['3mxw'],  # valid PDB ID
+        '',
+        'invalid_pdb_id',
+        '3mxw',  # valid PDB ID
         # This exits by raising an exception - disable for now.
-        # ['mmCIF_file=tests/data/invalid_file_name'],
-        ['mmCIF_file=tests/data/3mxw.cif'],  # valid file name
+        # 'mmCIF_file=tests/data/invalid_file_name',
+        'mmCIF_file=tests/data/3mxw.cif',  # valid file name
         ['3mxw', 'mmCIF_file=tests/data/3mxw.cif'],  # both
     ])
 def test_run_main(argv):
+    # Finish launching PyMOL without GUI.
+    if sys.version_info[0] == 2:
+        # Under pytest this apparently works only for python2. But it appears
+        # that PyMOL under python3 is happy enough without this call.
+        pymol.finish_launching(['pymol', '-cq'])
+
     # Load and initialize the module and attempt main().
     # We just want to make sure nothing is crashing at this point.
 
@@ -36,6 +43,9 @@ def test_run_main(argv):
     pref_loglevel = 'PDB_PLUGIN_LOGLEVEL'
     pymol.plugins.pref_set(pref_loglevel, 'DEBUG')
 
+    # We allow argv singletons for convenience; now wrap them.
+    if not isinstance(argv, list):
+        argv = [argv]
     plugin.main(argv)
     plugin.count_chains()
 


### PR DESCRIPTION
In particular, improper startup caused pymol commands to misbehave under
PyMOL 2.0, like returning int or None types when they should return list.

This fixes #3 